### PR TITLE
feat: extract pull request title in new UI as well

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -57,6 +57,24 @@ async function getPRInfo() {
     target: { tabId: tab.id },
     args: [isPullRequest],
     func: (isPullRequest) => {
+      function extractPullRequestTitle() {
+        const oldFormatTitle = /** @type {HTMLElement} */ (document.querySelector('.gh-header-title .js-issue-title'))
+
+        if (oldFormatTitle) {
+          return oldFormatTitle.innerText.trim()
+        }
+
+        const newFormatTitle = /** @type {HTMLElement} */ (document.querySelector('.markdown-title'))
+
+        return newFormatTitle ? newFormatTitle.innerText.trim() : '(No title found)'
+      }
+
+      function extractIssueTitle() {
+        const title = /** @type {HTMLElement} */ (document.querySelector('.markdown-title'))
+
+        return title ? title.innerText.trim() : '(No title found)'
+      }
+
       const pathParts = window.location.pathname.split('/')
       // github.com/owner/repo-name/pull/7/files --> ['', 'owner', 'repo-name', 'pull', '7', 'files']
       const repoName = pathParts.at(2) ?? ''
@@ -64,9 +82,7 @@ async function getPRInfo() {
         .replace(/[-_]/g, ' ')
         .replace(/\b\w/g, substring => substring.toUpperCase())
 
-      const titleSelector = isPullRequest ? '.gh-header-title .js-issue-title' : '.markdown-title'
-      const titleElement = /** @type {HTMLElement} */ (document.querySelector(titleSelector))
-      const title = titleElement ? titleElement.innerText.trim() : '(No title found)'
+      const title = isPullRequest ? extractPullRequestTitle() : extractIssueTitle()
 
       const referenceHref = `${window.location.origin}/${pathParts.slice(1, 5).join('/')}`
 


### PR DESCRIPTION
Close #1

# Details

New Github UI has different title selector when reviewing changes. This pull request uses appropriate selector if old format doesn't work.